### PR TITLE
add gps suport via /heartbeat

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -773,7 +773,7 @@ X-API-Key: <api_secret_key>
 **Endpoint:** `POST /hardware/:id/heartbeat`
 **Auth Required:** Hardware API Key
 
-**Description:** Hardware endpoint for trucks to send heartbeat and status updates.
+**Description:** Hardware endpoint for trucks to send heartbeat and status updates. GPS coordinates are optional and can be included to track truck location.
 
 **Headers:**
 ```
@@ -786,9 +786,24 @@ X-API-Key: <api_secret_key>
   "device_id": "TRUCK_001",
   "status": "online",
   "uptime_seconds": 3600,
-  "last_ad_playback_timestamp": "2024-01-15T10:30:00.000Z"
+  "last_ad_playback_timestamp": "2024-01-15T10:30:00.000Z",
+  "gps_coordinates": {
+    "latitude": 19.0760,
+    "longitude": 72.8777,
+    "timestamp": "2024-01-15T10:30:00.000Z"
+  }
 }
 ```
+
+**Field Descriptions:**
+- `device_id` (string, required): Truck controller identifier
+- `status` (string, required): Current status ("online" or "offline")
+- `uptime_seconds` (number, required): Uptime in seconds since last reboot
+- `last_ad_playback_timestamp` (ISO date, optional): When last ad was played
+- `gps_coordinates` (object, optional): GPS location data
+  - `latitude` (number, required if gps_coordinates provided): Latitude (-90 to 90)
+  - `longitude` (number, required if gps_coordinates provided): Longitude (-180 to 180)
+  - `timestamp` (ISO date, optional): When GPS reading was taken (defaults to request time)
 
 **Response (200):**
 ```json

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -71,7 +71,12 @@ const schemas = {
     device_id: Joi.string().required(),
     status: Joi.string().valid('online', 'offline').required(),
     uptime_seconds: Joi.number().min(0).required(),
-    last_ad_playback_timestamp: Joi.date().optional()
+    last_ad_playback_timestamp: Joi.date().optional(),
+    gps_coordinates: Joi.object({
+      latitude: Joi.number().min(-90).max(90).required(),
+      longitude: Joi.number().min(-180).max(180).required(),
+      timestamp: Joi.date().optional()
+    }).optional()
   })
 };
 

--- a/models/Truck.js
+++ b/models/Truck.js
@@ -27,6 +27,33 @@ const truckSchema = new mongoose.Schema({
   lastAdPlaybackTimestamp: {
     type: Date
   },
+  gpsCoordinates: {
+    latitude: {
+      type: Number,
+      min: -90,
+      max: 90,
+      validate: {
+        validator: function(v) {
+          return v === null || (typeof v === 'number' && !isNaN(v));
+        },
+        message: 'Latitude must be a valid number between -90 and 90'
+      }
+    },
+    longitude: {
+      type: Number,
+      min: -180,
+      max: 180,
+      validate: {
+        validator: function(v) {
+          return v === null || (typeof v === 'number' && !isNaN(v));
+        },
+        message: 'Longitude must be a valid number between -180 and 180'
+      }
+    },
+    timestamp: {
+      type: Date
+    }
+  },
   isActive: {
     type: Boolean,
     default: true

--- a/routes/hardware.js
+++ b/routes/hardware.js
@@ -23,7 +23,7 @@ const authenticateHardware = (req, res, next) => {
 router.post('/:id/heartbeat', authenticateHardware, validateRequest(schemas.truckHeartbeat), async (req, res) => {
   try {
     const { id } = req.params;
-    const { device_id, status, uptime_seconds, last_ad_playback_timestamp } = req.body;
+    const { device_id, status, uptime_seconds, last_ad_playback_timestamp, gps_coordinates } = req.body;
 
     const truck = await Truck.findById(id);
     if (!truck) {
@@ -36,6 +36,15 @@ router.post('/:id/heartbeat', authenticateHardware, validateRequest(schemas.truc
     truck.uptimeSeconds = uptime_seconds;
     if (last_ad_playback_timestamp) {
       truck.lastAdPlaybackTimestamp = new Date(last_ad_playback_timestamp);
+    }
+
+    // Update GPS coordinates if provided
+    if (gps_coordinates) {
+      truck.gpsCoordinates = {
+        latitude: gps_coordinates.latitude,
+        longitude: gps_coordinates.longitude,
+        timestamp: gps_coordinates.timestamp ? new Date(gps_coordinates.timestamp) : new Date()
+      };
     }
 
     await truck.save();


### PR DESCRIPTION
expected body for endpoint 


{
  "device_id": "CTRL-TRUCK-001",
  "status": "online",
  "uptime_seconds": 1860,
  "last_ad_playback_timestamp": "2025-09-29T06:35:40.000Z",
  "gps_coordinates": {
    "latitude": 19.0760,
    "longitude": 72.8777,
    "timestamp": "2025-09-29T06:35:40.000Z"
  }
}